### PR TITLE
Update repo

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,7 @@
 import nibabel
 import importlib
 import dash
-import dash_core_components as dcc
-import dash_html_components as html
+from dash import dcc, html
 import numpy as np
 from dash.dependencies import Input, Output, State
 import mne

--- a/app.py
+++ b/app.py
@@ -90,12 +90,12 @@ def plotly_triangular_mesh(vertices, faces, intensities=None, colorscale="Viridi
 
 data_path = mne.datasets.sample.data_path()
 
-fname_inv = data_path + '/MEG/sample/sample_audvis-meg-oct-6-meg-inv.fif'
-fname_evoked = data_path + '/MEG/sample/sample_audvis-ave.fif'
-freesurfer_path = data_path + "/subjects/sample/surf/"
+fname_inv = data_path / 'MEG/sample/sample_audvis-meg-oct-6-meg-inv.fif'
+fname_evoked = data_path / 'MEG/sample/sample_audvis-ave.fif'
+freesurfer_path = data_path / "subjects/sample/surf/"
 
-lh = nibabel.freesurfer.io.read_geometry(freesurfer_path + "lh.inflated")[0]
-rh = nibabel.freesurfer.io.read_geometry(freesurfer_path + "rh.inflated")[0]
+lh = nibabel.freesurfer.io.read_geometry(freesurfer_path / "lh.inflated")[0]
+rh = nibabel.freesurfer.io.read_geometry(freesurfer_path / "rh.inflated")[0]
 rh[:, 0] = rh[:, 0] + 85
 
 snr = 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ nibabel
 colorlover>=0.2.1
 numpy>=1.16.2
 scipy>=1.2.1
+scikit-learn


### PR DESCRIPTION
Closes #1 

- MNE uses `pathlib` for its dataset paths now, update path handling 
- Update dash imports because `dash_core_components` is deprecated (just use `from dash import dcc`).
- This demo imports `scikit-learn` but it is not listed in the requirements.txt file (I assume that it should be).